### PR TITLE
ci: make CI manual-dispatch only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,10 +1,6 @@
 name: CI
 
 on:
-  push:
-    branches: [main]
-    tags: ["v*.*.*"]
-  pull_request:
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Reduces `.github/workflows/ci.yml` to `on: workflow_dispatch:`. Job definitions unchanged.

Agents A/B/C push across all eight program repos concurrently; the full Rust matrix on every push and pull_request is not worth the compute during the v0.1 build-out.

Run on demand:

```
gh workflow run CI --repo agent-ix/quire-analyze --ref <branch>
```

Refs agent-ix/quire-contract-ir#13